### PR TITLE
enterprise_parser support link message

### DIFF
--- a/tests/test_enterprise_parser.py
+++ b/tests/test_enterprise_parser.py
@@ -84,6 +84,23 @@ class ParseMessageTestCase(unittest.TestCase):
         msg = parse_message(xml)
         self.assertEqual('location', msg.type)
 
+    def test_parse_link_message(self):
+        xml = """<xml>
+        <ToUserName><![CDATA[toUser]]></ToUserName>
+        <FromUserName><![CDATA[fromUser]]></FromUserName>
+        <CreateTime>1351776360</CreateTime>
+        <MsgType><![CDATA[link]]></MsgType>
+        <Title><![CDATA[公众平台官网链接]]></Title>
+        <Description><![CDATA[公众平台官网链接]]></Description>
+        <Url><![CDATA[url]]></Url>
+        <PicUrl><![CDATA[picurl]]></PicUrl>
+        <MsgId>1234567890123456</MsgId>
+        <AgentID>1</AgentID>
+        </xml>"""
+
+        msg = parse_message(xml)
+        self.assertEqual('link', msg.type)
+
     def test_parse_subscribe_event(self):
         xml = """<xml>
         <ToUserName><![CDATA[toUser]]></ToUserName>

--- a/wechatpy/enterprise/messages.py
+++ b/wechatpy/enterprise/messages.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-from wechatpy.fields import IntegerField
+from wechatpy.fields import IntegerField, StringField
 from wechatpy import messages
 
 
@@ -43,3 +43,8 @@ class VideoMessage(messages.VideoMessage):
 @register_message('location')
 class LocationMessage(messages.LocationMessage):
     agent = IntegerField('AgentID', 0)
+
+@register_message('link')
+class LinkMessage(messages.LinkMessage):
+    agent = IntegerField('AgentID', 0)
+    pic_url = StringField('PicUrl')


### PR DESCRIPTION
微信企业号支持link消息，容许员工转发link消息到企业号。
这个pull request 增加了企业号link消息解析，已实际测试通过。
